### PR TITLE
fix vagrant.sh for unix systems

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LOCKFILE=~/scripts/vagrant.lock
+LOCKFILE=vagrant.lock
 if [ -e ${LOCKFILE} ] && kill -0 `cat ${LOCKFILE}`; then
     echo "already running"
     exit
@@ -21,3 +21,4 @@ else
 fi
 
 rm -f ${LOCKFILE}
+end


### PR DESCRIPTION
Switched \r\n at end of each line to \n to make it work on unix systems.
Not sure if it works as it should on Windows systems.

Used dos2unix command to convert the file.